### PR TITLE
Add workers rules

### DIFF
--- a/AutoScaler.cs
+++ b/AutoScaler.cs
@@ -162,6 +162,9 @@ namespace Azure.SQL.DB.Hyperscale.Tools
                     return;
                 }
 
+                // If the average reaches at least one of the conditions, then the scale up is necessary.
+                // Unlike Scale Down, where all conditions must be met.
+
                 // Scale Up
                 if (usageInfo.MovingAvgCpuPercent > autoscalerConfig.HighCpuPercent ||
                     usageInfo.MovingAvgWorkersPercent > autoscalerConfig.HighWorkersPercent)
@@ -173,6 +176,10 @@ namespace Azure.SQL.DB.Hyperscale.Tools
                         conn.Execute($"ALTER DATABASE [{databaseName}] MODIFY (SERVICE_OBJECTIVE = '{targetSlo}')");
                     }
                 }
+
+                // Unlike Scale Up, we have here a "AND" condition, this is because it only makes sense to decrease
+                // if all the requirements are lower than expected, while for Scale Up one of them is necessary, so there,
+                // we have an "OR" condition
 
                 // Scale Down
                 if (usageInfo.MovingAvgCpuPercent < autoscalerConfig.LowCpuPercent &&

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Guidance on onboarding samples to docs.microsoft.com/samples: https://review.doc
 Taxonomies for products and languages: https://review.docs.microsoft.com/new-hope/information-architecture/metadata/taxonomies?branch=master
 -->
 
-This is a sample on how autoscaling of Azure SQL DB Hyperscale can be implemented using Azure Functions. The code just uses a simple moving average on the CPU load for the last minute; if the value is outside minimum or maximum boundaries it will initiate a scale-up or scale-down.
+This is a sample on how autoscaling of Azure SQL DB Hyperscale can be implemented using Azure Functions. The code just uses a simple moving average on the CPU or Workers load for the last minute; if the value is outside minimum or maximum boundaries it will initiate a scale-up or scale-down.
 
 A detailed article related to this repository is available here:
 
@@ -50,15 +50,18 @@ Deploy the solution to an Azure Function and then add the following [application
 
 ```json
 "AzureSQLConnection": "...",
-"HighThreshold": 70,
-"LowThreshold": 20,
+"HighCpuPercent": 70,
+"LowCpuPercent": 20,
+"HighWorkersPercent": 80,
+"LowWorkersPercent": 30,
 "vCoreMin": 2,
 "vCoreMax": 8,
 "RequiredDataPoints": 5
 ```
 
 - AzureSQLConnection: Connection string to Azure SQL Hyperscale to monitor. Make sure the user used to login to the database has the [right permission](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql?view=azuresqldb-current#permissions-1) to run ALTER DATABASE command.
-- HighThreshold, LowThreshold: the minium and maximum threshold values after which scaling up or down will be initiated
+- HighCpuPercent, LowCpuPercent: the minium and maximum CPU threshold values after which scaling up or down will be initiated
+- HighWorkersPercent, LowWorkersPercent: the minium and maximum Workers threshold values after which scaling up or down will be initiated
 - vCoreMax, vCoreMin: the maximum and minimum number of cores you want to use as limits to scale up and down
 - RequiredDataPoints: Number of data points that needs to be gathered before initiating any autoscale action
 


### PR DESCRIPTION
This implements a new rule for analyzing the limit on the number of workers, which in many scenarios, can compromise the stability of the server while it is expected to be scalable under chaotic scenarios.

See the image below;

![Screenshot 2023-06-24 101426](https://github.com/Azure-Samples/azure-sql-db-hyperscale-autoscaler/assets/4604923/bcca5915-aaa4-4673-b0bf-d4140d63d63c)
> Note that before ~9:30 am the CPU was below the limit, however the number of workers had already reached 100%, causing the following SQL error:
```
The request limit for the database is 600 and has been reached. 
See 'https://docs.microsoft.com/azure/azure-sql/database/resource-limits-logical-server' for assistance
``` 
So I implemented a new rule that takes the average amount of workers and then scales up when one of the CPU or Workers conditions is needed and scales down when both conditions are met.
