### PR TITLE
fixed available SLO index

### DIFF
--- a/AutoScaler.cs
+++ b/AutoScaler.cs
@@ -197,7 +197,7 @@ namespace Azure.SQL.DB.Hyperscale.Tools
         {
             var targetSLO = currentSLO;
             var availableSlos = HyperscaleSLOs[currentSLO.Generation];
-            var index = availableSlos.IndexOf(currentSLO.ToString());
+            var index = availableSlos.IndexOf(currentSLO.ToString().ToLower());
 
             if (direction == SearchDirection.Next && index < availableSlos.Count)
                 targetSLO = HyperScaleTier.Parse(availableSlos[index + 1]);


### PR DESCRIPTION
All GEN4 and GEN5 listed are in lower case but the SQL query returns camel case.
So was not working without this fix.